### PR TITLE
Flask-IIIF v0.1.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,9 @@
-Changelog
-=========
+Changes
+=======
 
 Here you can see the full list of changes between each Flask-IIIF
 release.
 
-Version 0.1
+Version 0.1.0 (released 2015-04-28)
 
 - Initial public release.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-IIIF
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 
 include *.py *.sh
-include .coveragerc pytest.ini run-tests.sh
+include .coveragerc .travis.yml pytest.ini run-tests.sh
 include README.rst CHANGES CONTRIBUTING.rst AUTHORS LICENSE MANIFEST.in
 include RELEASE-NOTES.rst
 include docs/*.rst docs/*.py docs/Makefile
 include tox.ini tests/*.py
 recursive-include docs/_templates *.html
 recursive-include docs/_themes *.py *.css *.css_t *.conf *.html
+recursive-include flask_iiif *.py

--- a/README.rst
+++ b/README.rst
@@ -1,30 +1,34 @@
-===========
+============
  Flask-IIIF
-===========
+============
 
 .. image:: https://travis-ci.org/inveniosoftware/flask-iiif.png?branch=master
     :target: https://travis-ci.org/inveniosoftware/flask-iiif
 .. image:: https://coveralls.io/repos/inveniosoftware/flask-iiif/badge.png?branch=master
     :target: https://coveralls.io/r/inveniosoftware/flask-iiif
 .. image:: https://pypip.in/v/Flask-IIIF/badge.png
-   :target: https://pypi.python.org/pypi/Flask-IIIF/
+    :target: https://pypi.python.org/pypi/Flask-IIIF/
 .. image:: https://pypip.in/d/Flask-IIIF/badge.png
-   :target: https://pypi.python.org/pypi/Flask-IIIF/
+    :target: https://pypi.python.org/pypi/Flask-IIIF/
 
 About
 =====
-Flask-IIIF is a Flask extension permitting to set up Shibboleth
-Single-Sign-On authentication in Flask based web applications.
+
+Flask-IIIF is a Flask extension permitting easy integration with the
+International Image Interoperability Framework (IIIF) API standards.
 
 Installation
 ============
+
 Flask-IIIF is on PyPI so all you need is: ::
 
     pip install Flask-IIIF
 
 Documentation
 =============
-Documentation is readable at http://flask-iiif.readthedocs.org or can be built using Sphinx: ::
+
+Documentation is readable at http://flask-iiif.readthedocs.org or can be
+built using Sphinx: ::
 
     git submodule init
     git submodule update

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,18 +1,19 @@
-==============================
+===============================
  Flask-IIIF v0.1.0 is released
-==============================
+===============================
 
-Flask-IIIF v0.1.0 was released on FIXME.
+Flask-IIIF v0.1.0 was released on April 28, 2015.
 
 About
 -----
 
-Flask-IIIF is a Flask extension FIXME.
+Flask-IIIF is a Flask extension permitting easy integration with the
+International Image Interoperability Framework (IIIF) API standards.
 
 What's new
 ----------
 
-- FIXME
+- Initial public release.
 
 Installation
 ------------
@@ -22,7 +23,7 @@ Installation
 Documentation
 -------------
 
-   http://flask-iiif.readthedocs.org/
+   http://flask-iiif.readthedocs.org/en/v0.1.0
 
 Homepage
 --------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,8 +18,8 @@
     </p>
 
 
-Flask-IIIF is a Flask extension permitting easy integration with the image
-IIIF API standards.
+Flask-IIIF is a Flask extension permitting easy integration with the
+International Image Interoperability Framework (IIIF) API standards.
 
 Contents
 --------

--- a/flask_iiif/version.py
+++ b/flask_iiif/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-IIIF
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -16,4 +16,4 @@ This file is imported by ``flask_iiif.__init__``, and parsed by
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "0.1.0.dev20141022"
+__version__ = "0.1.0"

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 
+"""Flask-IIIF extension provides easy IIIF API standard integration."""
+
 import os
 import re
 import sys
@@ -72,7 +74,7 @@ setup(
     license='BSD',
     author='Invenio collaboration',
     author_email='info@invenio-software.org',
-    description='Flask-IIIF multimedia extension.',
+    description=__doc__,
     long_description=open('README.rst').read(),
     packages=['flask_iiif'],
     zip_safe=False,


### PR DESCRIPTION
* Initial public release.  (closes #4)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>

--
cc @tiborsimko @drjova 