### PR TITLE
flask_iiif: image information response

### DIFF
--- a/flask_iiif/config.py
+++ b/flask_iiif/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-IIIF
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -47,7 +47,18 @@
         `IIIF Image API v2
         <http://iiif.io/api/image/2.0/>`_
 
+.. py:data:: IIIF_API_INFO_RESPONSE_SKELETON
+
+    Information request document for the image.
+
+    .. seealso::
+        `IIIF Image API v1 Information request
+        <http://iiif.io/api/image/1.1/#information-request>`_ and
+        `IIIF Image API v2 Information request
+        <http://iiif.io/api/image/2.0/#information-request>`_
+
 """
+
 # Cache handler
 IIIF_CACHE_HANDLER = 'flask_iiif.cache.simple:ImageSimpleCache'
 
@@ -133,4 +144,42 @@ IIIF__MODE = {
     'YCbCr': ['default', 'color', 'gray', 'bitonal'],
     'I': ['default', 'color', 'gray', 'bitonal'],
     'F': ['default', 'color', 'gray', 'bitonal']
+}
+
+# API Info
+IIIF_API_INFO_RESPONSE_SKELETON = {
+    "v1": {
+        "@context": (
+            "http://library.stanford.edu/iiif/image-api/1.1/context.json"
+        ),
+        "@id": "",
+        "width": "",
+        "height": "",
+        "profile": (
+            "http://library.stanford.edu/iiif/image-api/compliance.html#level1"
+        ),
+        "tile_width": 256,
+        "tile_height": 256,
+        "scale_factors": [
+            1, 2, 4, 8, 16, 32, 64
+        ]
+    },
+    "v2": {
+        "@context": "http://iiif.io/api/image/2/context.json",
+        "@id": "",
+        "protocol": "http://iiif.io/api/image",
+        "width": "",
+        "height": "",
+        "tiles": [
+            {
+                "width": 256,
+                "scaleFactors": [
+                    1, 2, 4, 8, 16, 32, 64
+                ]
+            }
+        ],
+        "profile": [
+            "http://iiif.io/api/image/2/level2.json",
+        ]
+    }
 }

--- a/flask_iiif/restful.py
+++ b/flask_iiif/restful.py
@@ -11,8 +11,11 @@
 
 from io import BytesIO
 
-from flask import current_app, send_file
-from flask.ext.restful import Resource, abort
+from flask import current_app, jsonify, redirect, send_file, url_for
+
+from flask_restful import Resource
+from flask_restful.utils import cors
+
 
 from werkzeug import LocalProxy
 
@@ -30,6 +33,68 @@ from .signals import (
 )
 
 current_iiif = LocalProxy(lambda: current_app.extensions['iiif'])
+
+
+class IIIFImageBase(Resource):
+
+    """IIIF Image Base."""
+
+    def get(self, version, uuid):
+        """Get IIIF Image Base.
+
+        .. note::
+
+            I will redirect to ``iiifimageinfo`` endpoint with status code
+            303.
+        """
+        return redirect(
+            url_for('iiifimageinfo', version=version, uuid=uuid), code=303
+        )
+
+
+class IIIFImageInfo(Resource):
+
+    """IIIF Image Info."""
+
+    method_decorators = [
+        error_handler,
+    ]
+
+    @cors.crossdomain(origin='*', methods='GET')
+    def get(self, version, uuid):
+        """Get IIIF Image Info."""
+        # Check if its cached
+        cache_handler = current_iiif.cache()
+
+        # build the image key
+        key = "iiif:info:{0}/{1}".format(
+            version, uuid
+        )
+
+        # Check if its cached
+        cached = cache_handler.get(key)
+
+        # If the image size is cached loaded from cache
+        if cached:
+            width, height = map(int, cached.split(','))
+        else:
+            data = current_iiif.uuid_to_image_opener(uuid)
+            image = IIIFImageAPIWrapper.open_image(data)
+            width, height = image.size()
+            cache_handler.set(key, "{0},{1}".format(width, height))
+
+        data = current_app.config['IIIF_API_INFO_RESPONSE_SKELETON'][version]
+
+        base_uri = url_for(
+            'iiifimagebase',
+            uuid=uuid,
+            version=version,
+            _external=True
+        )
+        data["@id"] = base_uri
+        data["width"] = width
+        data["height"] = height
+        return jsonify(data)
 
 
 class IIIFImageAPI(Resource):
@@ -130,23 +195,3 @@ class IIIFImageAPI(Resource):
         # Trigger event after proccess the api request
         iiif_after_process_request.send(self, **api_after_request_parameters)
         return send_file(to_serve, mimetype=mimetype)
-
-    def post(self):
-        """post."""
-        abort(405)
-
-    def delete(self):
-        """delete."""
-        abort(405)
-
-    def options(self):
-        """options."""
-        abort(405)
-
-    def put(self):
-        """put."""
-        abort(405)
-
-    def head(self):
-        """head."""
-        abort(405)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -55,6 +55,22 @@ class IIIFTestCase(TestCase):
         """Simulate a GET request."""
         return self.make_request(self.client.get, *args, **kwargs)
 
+    def post(self, *args, **kwargs):
+        """Simulate a POST request."""
+        return self.make_request(self.client.post, *args, **kwargs)
+
+    def put(self, *args, **kwargs):
+        """Simulate a PUT request."""
+        return self.make_request(self.client.put, *args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        """Simulate a DELETE request."""
+        return self.make_request(self.client.delete, *args, **kwargs)
+
+    def patch(self, *args, **kwargs):
+        """Simulate a PATCH request."""
+        return self.make_request(self.client.patch, *args, **kwargs)
+
     def make_request(self, client_func, endpoint, urlargs={}):
         """Simulate a request."""
         url = url_for(endpoint, **urlargs)


### PR DESCRIPTION
* NEW Adds image information request endpoint `<uuid>/info.json`
  which contains the available metadata for the image such as
  full height, width and functionality available for it such
  as the formats in which it may retrieved and the IIIF profile
  that is used.

* BETTER Improves the testing and increases the coverage to 98%.

* BETTER Improves the initialization of the REST API adding the
  possibility to override the default API prefix
  `/api/multimedia/image/`.

Signed-off-by: Harris Tzovanakis <me@drjova.com>