### PR TITLE
api: extracts resampling method as config variable

### DIFF
--- a/flask_iiif/api.py
+++ b/flask_iiif/api.py
@@ -16,7 +16,8 @@ import re
 
 from flask import current_app
 from PIL import Image
-from six import BytesIO
+from six import BytesIO, string_types
+from werkzeug import import_string
 
 from .errors import IIIFValidatorError, MultimediaImageCropError, \
     MultimediaImageFormatError, MultimediaImageNotFound, \
@@ -110,7 +111,7 @@ class MultimediaImage(MultimediaObject):
         image = Image.open(source)
         return cls(image)
 
-    def resize(self, dimensions, resample=Image.NEAREST):
+    def resize(self, dimensions, resample=None):
         """Resize the image.
 
         :param str dimensions: The dimensions to resize the image
@@ -129,6 +130,13 @@ class MultimediaImage(MultimediaObject):
 
         """
         real_width, real_height = self.image.size
+        if resample is None:
+            if isinstance(current_app.config['IIIF_RESIZE_RESAMPLE'],
+                          string_types):
+                resample = import_string(
+                    current_app.config['IIIF_RESIZE_RESAMPLE'])
+            else:
+                resample = current_app.config['IIIF_RESIZE_RESAMPLE']
 
         # Check if it is `pct:`
         if dimensions.startswith('pct:'):

--- a/flask_iiif/config.py
+++ b/flask_iiif/config.py
@@ -58,6 +58,8 @@
         <http://iiif.io/api/image/2.0/#information-request>`_
 
 """
+# Resampling method
+IIIF_RESIZE_RESAMPLE = 'PIL.Image:NEAREST'
 
 # Cache handler
 IIIF_CACHE_HANDLER = 'flask_iiif.cache.simple:ImageSimpleCache'


### PR DESCRIPTION
- BETTER Adds the config variable `IIIF_RESAMPLING` with default
  `PIL.Image:NEAREST` (closes #17)

Signed-off-by: Øystein Blixhavn oystein@blixhavn.no
