### PR TITLE
cache: initialize default cache handler

### DIFF
--- a/flask_iiif/cache/simple.py
+++ b/flask_iiif/cache/simple.py
@@ -10,6 +10,7 @@
 """Implement a simple cache."""
 
 from __future__ import absolute_import
+
 from werkzeug.contrib.cache import SimpleCache
 
 from .cache import ImageCache
@@ -52,3 +53,5 @@ class ImageSimpleCache(ImageCache):
     def flush(self):
         """Flush the cache."""
         self.cache.clear()
+
+cache = ImageCache()

--- a/flask_iiif/config.py
+++ b/flask_iiif/config.py
@@ -60,7 +60,7 @@
 """
 
 # Cache handler
-IIIF_CACHE_HANDLER = 'flask_iiif.cache.simple:ImageSimpleCache'
+IIIF_CACHE_HANDLER = 'flask_iiif.cache.simple:cache'
 
 # Cache duration
 # 60 seconds * 60 minutes (1 hour) * 24 (24 hours) * 2 (2 days) = 172800 secs


### PR DESCRIPTION
- FIX Initializes the default cache handler `ImageSimpleCache`
  because wasn't initialized.

Signed-off-by: Harris Tzovanakis me@drjova.com
