### PR TITLE
api: fix incompatible image mode saving

### DIFF
--- a/flask_iiif/api.py
+++ b/flask_iiif/api.py
@@ -317,7 +317,7 @@ class MultimediaImage(MultimediaObject):
         qualities = current_app.config['IIIF_QUALITIES']
         if quality not in qualities:
             raise MultimediaImageQualityError(
-                ("{0} does not supported, pleae select on of the"
+                ("{0} is not supported, please select one of the"
                  " valid qualities: {1}").format(quality, qualities)
             )
 
@@ -386,8 +386,8 @@ class MultimediaImage(MultimediaObject):
 
         .. note::
 
-            pdf format can't be saved as `RBGA` so image needs to be converted
-            to `RGB` mode.
+            pdf and jpeg format can't be saved as `RBGA` so image needs to be
+            converted to `RGB` mode.
 
         """
         image_format = self.sanitize_format_name(requested_format)
@@ -399,8 +399,8 @@ class MultimediaImage(MultimediaObject):
                  " formats: {1}").format(requested_format, format_keys)
             )
 
-        # If the the `requested_format` is pdf force mode to RGB
-        if image_format == "pdf":
+        # If the the `requested_format` is pdf or jpeg force mode to RGB
+        if image_format in ("pdf", "jpeg"):
             self.image = self.image.convert('RGB')
 
         return image_format

--- a/flask_iiif/config.py
+++ b/flask_iiif/config.py
@@ -134,7 +134,7 @@ IIIF_VALIDATIONS = {
 }
 
 # Qualities per image mode
-IIIF__MODE = {
+IIIF_MODE = {
     '1': ['default', 'bitonal'],
     'L': ['default', 'gray', 'bitonal'],
     'P': ['default', 'gray', 'bitonal'],

--- a/tests/test_multimedia_image_api.py
+++ b/tests/test_multimedia_image_api.py
@@ -51,6 +51,13 @@ class TestMultimediaAPI(IIIFTestCase):
         tmp_file.seek(0)
         self.image_not_rgba = MultimediaImage.from_string(tmp_file)
 
+        # Image in P Mode
+        tmp_file = BytesIO()
+        image = Image.new("P", (1280, 1024))
+        image.save(tmp_file, 'gif')
+        tmp_file.seek(0)
+        self.image_p_mode = MultimediaImage.from_string(tmp_file)
+
     def test_image_resize(self):
         """Test image resize function."""
         # Test image size before
@@ -163,6 +170,12 @@ class TestMultimediaAPI(IIIFTestCase):
         """Test image mode."""
         self.image_not_rgba.quality('grey')
         self.assertEqual(self.image_not_rgba.image.mode, "L")
+
+    def test_image_incompatible_modes(self):
+        """Test P-incompatible image to RGB auto-convert."""
+        tmp_file = BytesIO()
+        self.image_p_mode.save(tmp_file)
+        self.assertEqual(self.image_p_mode.image.mode, "RGB")
 
     def test_image_saving(self):
         """Test image saving."""


### PR DESCRIPTION
* FIX Adds JPEG to the formats that have to be converted to RGB
  in order to be saved/served. (closes #15)

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>