### PR TITLE
flask_iiif: addition of TIFF format default support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@ Contributors
 * Harris Tzovanakis <drjova@cern.ch>
 * Jiri Kuncar <jiri.kuncar@cern.ch>
 * Tibor Simko <tibor.simko@cern.ch>
+* Alexander Ioannidis <a.ioannidis@cern.ch>

--- a/flask_iiif/api.py
+++ b/flask_iiif/api.py
@@ -351,7 +351,7 @@ class MultimediaImage(MultimediaObject):
         """Store the image to the specific path.
 
         :param str path: absolute path
-        :param str image_format: (gif, jpeg, pdf, png)
+        :param str image_format: (gif, jpeg, pdf, png, tif)
         :param int quality: The image quality; [1, 100]
 
         .. note::
@@ -367,7 +367,7 @@ class MultimediaImage(MultimediaObject):
     def serve(self, image_format="png", quality=90):
         """Return a BytesIO object to easily serve it thought HTTTP.
 
-        :param str image_format: (gif, jpeg, pdf, png)
+        :param str image_format: (gif, jpeg, pdf, png, tif)
         :param int quality: The image quality; [1, 100]
 
         .. note::

--- a/flask_iiif/config.py
+++ b/flask_iiif/config.py
@@ -83,6 +83,7 @@ IIIF_FORMATS = {
     'jpg': 'image/jpeg',
     'pdf': 'application/pdf',
     'png': 'image/png',
+    'tif': 'image/tiff',
 }
 
 # Regular expressions to validate each parameter
@@ -107,7 +108,7 @@ IIIF_VALIDATIONS = {
         },
         "image_format": {
             "ignore": "",
-            "validate": "(jpg|png|gif|jp2|jpeg|pdf)"
+            "validate": "(jpg|png|gif|jp2|jpeg|pdf|tif)"
         }
     },
     "v2": {
@@ -130,7 +131,7 @@ IIIF_VALIDATIONS = {
         },
         "image_format": {
             "ignore": "",
-            "validate": "(jpg|png|gif|jp2|jpeg|pdf)"
+            "validate": "(jpg|png|gif|jp2|jpeg|pdf|tif)"
         }
     }
 }

--- a/tests/test_multimedia_image_api.py
+++ b/tests/test_multimedia_image_api.py
@@ -58,6 +58,13 @@ class TestMultimediaAPI(IIIFTestCase):
         tmp_file.seek(0)
         self.image_p_mode = MultimediaImage.from_string(tmp_file)
 
+        # TIFF Image
+        tmp_file = BytesIO()
+        image = Image.new("RGBA", (1280, 1024), (255, 0, 0, 0))
+        image.save(tmp_file, 'tiff')
+        tmp_file.seek(0)
+        self.image_tiff = MultimediaImage.from_string(tmp_file)
+
     def test_image_resize(self):
         """Test image resize function."""
         # Test image size before
@@ -184,3 +191,7 @@ class TestMultimediaAPI(IIIFTestCase):
         self.assertEqual(tmp_file.getvalue(), compare_file.getvalue())
         self.image_save.save(tmp_file)
         self.assertNotEqual(str(tmp_file.getvalue()), compare_file.getvalue())
+
+    def test_image_tiff_support(self):
+        """Test TIFF image support."""
+        self.assertEqual(self.image_tiff.image.format, 'TIFF')


### PR DESCRIPTION
- Adds TIFF image support to the default config.

Signed-off-by: Alexander Ioannidis a.ioannidis@cern.ch
