### PR TITLE
api: addition of parameter for custom filename

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,32 @@
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# Python files
+[*.py]
+indent_size = 4
+# isort plugin configuration
+known_first_party = flask_iiif
+multi_line_output = 2
+default_section = THIRDPARTY
+
+# RST files (used by sphinx)
+[*.rst]
+indent_size = 4
+
+# CSS, HTML, JS, JSON, YML
+[*.{css,html,js,json,yml}]
+indent_size = 2
+
+# Matches the exact files either package.json or .travis.yml
+[{package.json,.travis.yml}]
+indent_size = 2
+
+# Dockerfile
+[Dockerfile]
+indent_size = 4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-IIIF
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 Flask-IIIF is free software; you can redistribute it and/or modify it
 under the terms of the Revised BSD License quoted below.
 
-Copyright (C) 2013, 2014 CERN.
+Copyright (C) 2014, 2016 CERN.
 
 All rights reserved.
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-IIIF
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -9,9 +9,11 @@
 
 include *.py *.sh
 include .coveragerc .travis.yml pytest.ini run-tests.sh
+include .editorconfig .gitmodules
 include README.rst CHANGES CONTRIBUTING.rst AUTHORS LICENSE MANIFEST.in
 include RELEASE-NOTES.rst
 include docs/*.rst docs/*.py docs/Makefile
+include docs/_themes/LICENSE docs/_themes/README
 include tox.ini tests/*.py
 recursive-include docs/_templates *.html
 recursive-include docs/_themes *.py *.css *.css_t *.conf *.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-IIIF
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 
-import sys
+"""Sphinx configuration."""
+
 import os
 import re
+import sys
 
 sys.path.append(os.path.abspath('_themes'))
 
@@ -19,7 +21,7 @@ sys.path.append(os.path.abspath('_themes'))
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 
-# -- General configuration -----------------------------------------------------
+# -- General configuration -----------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
@@ -99,7 +101,7 @@ pygments_style = 'sphinx'
 #keep_warnings = False
 
 
-# -- Options for HTML output ---------------------------------------------------
+# -- Options for HTML output ---------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
@@ -187,24 +189,24 @@ html_sidebars = {
 htmlhelp_basename = 'Flask-IIIFdoc'
 
 
-# -- Options for LaTeX output --------------------------------------------------
+# -- Options for LaTeX output --------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'Flask-IIIF.tex', u'Flask-IIIF Documentation',
-   u'CERN', 'manual'),
+    ('index', 'Flask-IIIF.tex', u'Flask-IIIF Documentation',
+     u'CERN', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -228,7 +230,7 @@ latex_documents = [
 #latex_domain_indices = True
 
 
-# -- Options for manual page output --------------------------------------------
+# -- Options for manual page output --------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
@@ -241,15 +243,15 @@ man_pages = [
 #man_show_urls = False
 
 
-# -- Options for Texinfo output ------------------------------------------------
+# -- Options for Texinfo output ------------------------------------------
 
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'Flask-IIIF', u'Flask-IIIF Documentation',
-   u'CERN', 'Flask-IIIF', 'One line description of project.',
-   'Miscellaneous'),
+    ('index', 'Flask-IIIF', u'Flask-IIIF Documentation',
+     u'CERN', 'Flask-IIIF', 'One line description of project.',
+     'Miscellaneous'),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/flask_iiif/api.py
+++ b/flask_iiif/api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-IIIF
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -14,17 +14,14 @@ import math
 import os
 import re
 
-from PIL import Image
-
 from flask import current_app
-
+from PIL import Image
 from six import BytesIO
 
-from .errors import (
-    IIIFValidatorError, MultimediaImageCropError, MultimediaImageFormatError,
-    MultimediaImageNotFound, MultimediaImageQualityError,
-    MultimediaImageResizeError, MultimediaImageRotateError
-)
+from .errors import IIIFValidatorError, MultimediaImageCropError, \
+    MultimediaImageFormatError, MultimediaImageNotFound, \
+    MultimediaImageQualityError, MultimediaImageResizeError, \
+    MultimediaImageRotateError
 
 
 class MultimediaObject(object):

--- a/flask_iiif/cache/simple.py
+++ b/flask_iiif/cache/simple.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-IIIF
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -10,6 +10,7 @@
 """Implement a simple cache."""
 
 from __future__ import absolute_import
+
 from werkzeug.contrib.cache import SimpleCache
 
 from .cache import ImageCache

--- a/flask_iiif/config.py
+++ b/flask_iiif/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-IIIF
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for

--- a/flask_iiif/decorators.py
+++ b/flask_iiif/decorators.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-IIIF
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -12,17 +12,13 @@
 from functools import wraps
 
 from flask import current_app
-
 from flask_restful import abort
-
 from werkzeug import LocalProxy
 
-from .errors import (
-    IIIFValidatorError, MultimediaError, MultimediaImageCropError,
-    MultimediaImageFormatError, MultimediaImageNotFound,
-    MultimediaImageQualityError, MultimediaImageResizeError,
-    MultimediaImageRotateError
-)
+from .errors import IIIFValidatorError, MultimediaError, \
+    MultimediaImageCropError, MultimediaImageFormatError, \
+    MultimediaImageNotFound, MultimediaImageQualityError, \
+    MultimediaImageResizeError, MultimediaImageRotateError
 
 __all__ = ('api_decorator', 'error_handler', )
 

--- a/flask_iiif/restful.py
+++ b/flask_iiif/restful.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-IIIF
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -12,25 +12,13 @@
 from io import BytesIO
 
 from flask import current_app, jsonify, redirect, send_file, url_for
-
 from flask_restful import Resource
 from flask_restful.utils import cors
-
-
 from werkzeug import LocalProxy
 
-
-from .api import (
-    IIIFImageAPIWrapper
-)
-
-from .decorators import (
-    api_decorator, error_handler
-)
-
-from .signals import (
-    iiif_after_process_request, iiif_before_process_request
-)
+from .api import IIIFImageAPIWrapper
+from .decorators import api_decorator, error_handler
+from .signals import iiif_after_process_request, iiif_before_process_request
 
 current_iiif = LocalProxy(lambda: current_app.extensions['iiif'])
 

--- a/flask_iiif/signals.py
+++ b/flask_iiif/signals.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-IIIF
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for

--- a/flask_iiif/utils.py
+++ b/flask_iiif/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-IIIF
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 #
 # This file is part of Flask-IIIF
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 
-pydocstyle flask_iiif
-check-manifest --ignore ".travis-*" --ignore docs/_themes
-sphinx-build -qnNW docs docs/_build/html
+pydocstyle flask_iiif && \
+isort -c -c -df **/*.py && \
+check-manifest --ignore ".travis-*" --ignore docs/_themes && \
+sphinx-build -qnNW docs docs/_build/html && \
 python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-IIIF
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -59,6 +59,7 @@ tests_require = [
     'flask-testing>=0.4.1',
     'check-manifest>=0.25',
     'coverage>=3.7,<4.0',
+    'isort>=4.2.2',
     'pydocstyle>=1.0.0',
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
@@ -77,15 +78,13 @@ install_requires = [
 extra_require = {
     'docs': [
         'sphinx>=1.3',
-    ]
+    ],
+    'tests': tests_require,
 }
 
 extra_require['all'] = []
 for reqs in extra_require.values():
     extra_require['all'].extend(reqs)
-
-if tuple(sys.version_info) < (2, 7):
-    install_requires.append('ordereddict')
 
 setup(
     name='Flask-IIIF',

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,11 +10,9 @@
 """Flask-IIIF test helpers."""
 
 from contextlib import contextmanager
-
 from io import BytesIO
 
 from flask import Flask, abort, url_for
-
 from flask_testing import TestCase
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -69,9 +69,9 @@ class IIIFTestCase(TestCase):
         """Simulate a PATCH request."""
         return self.make_request(self.client.patch, *args, **kwargs)
 
-    def make_request(self, client_func, endpoint, urlargs={}):
+    def make_request(self, client_func, endpoint, urlargs=None):
         """Simulate a request."""
-        url = url_for(endpoint, **urlargs)
+        url = url_for(endpoint, **(urlargs or {}))
         response = client_func(
             url,
             base_url=self.app.config['SITE_URL']

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -15,7 +15,8 @@ from unittest import TestCase
 
 from flask import Flask
 
-from flask_iiif import IIIF, config as default_config
+from flask_iiif import config as default_config
+from flask_iiif import IIIF
 
 
 class TestIIIF(TestCase):

--- a/tests/test_multimedia_image_api.py
+++ b/tests/test_multimedia_image_api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Flask-IIIF
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for

--- a/tests/test_restful_api.py
+++ b/tests/test_restful_api.py
@@ -11,9 +11,8 @@
 
 from io import BytesIO
 
-from PIL import Image
-
 from flask import url_for
+from PIL import Image
 
 from .helpers import IIIFTestCase
 


### PR DESCRIPTION
* Adds checking of `dl` request parameter for providing a custom
  filename. (closes #29)

* Removes duplicate lines that triggered iiif_after_process_request
  signal twice.

Signed-off-by: Øystein Blixhavn <oystein@blixhavn.no>