### PR TITLE
api: fix best fit for thumbnail, add background

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,18 @@ Changes
 Here you can see the full list of changes between each Flask-IIIF
 release.
 
+Version 0.5.0 (released 2018-05-18)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
++ Fixes
+
+  - wrong ratio calculation for best fit
+
++ New features
+
+  - adds black background to requested best fit thumbnail or gif
+    if the image does not cover the whole window of requested size
+
+
 Version 0.4.0 (released 2018-04-17)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/flask_iiif/utils.py
+++ b/flask_iiif/utils.py
@@ -103,3 +103,41 @@ def resize_gif(image, size, resample):
     """
     return create_gif_from_frames([frame.resize(size, resample=resample)
                                   for frame in ImageSequence.Iterator(image)])
+
+
+def resize_with_background_gif(image, size, resample, demand_w=0, demand_h=0):
+    """Resize a GIF image and fills the missing pixels with black background.
+
+    :param image: the original GIF image
+    :param size: the dimensions to resize to
+    :param resample: the method of resampling
+    :param demand_w: demanded height for thumbnail
+    :param demand_h: demanded width for thumbnail
+    :returns: resized GIF image
+    :rtype: PIL.Image
+    """
+    return create_gif_from_frames([fill_background(
+        frame.resize(size, resample=resample), demand_w, demand_h)
+        for frame in ImageSequence.Iterator(image)])
+
+
+def fill_background(image, demand_width, demand_height):
+    """Fill the background with black (in case of image too small).
+
+    :param image: image which does not fit into the window
+    :param demand_width: demanded thumbnail window width
+    :param demand_height: demanded window height
+    :returns: image of requested size, filled with black background
+    :rtype: PIL.Image
+    """
+    background = Image.new('RGB', (demand_width, demand_height))
+    offset_x, offset_y = 0, 0
+    w, h = image.size
+    if w < demand_width:
+        # set the image in the middle of x axis
+        offset_x = max(1, int((demand_width - w) / 2))
+    if h < demand_height:
+        # set the image in the middle of y axis
+        offset_y = max(1, int((demand_height - h) / 2))
+    background.paste(image, (offset_x, offset_y))
+    return background

--- a/flask_iiif/version.py
+++ b/flask_iiif/version.py
@@ -16,4 +16,4 @@ This file is imported by ``flask_iiif.__init__``, and parsed by
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/tests/test_multimedia_image_api.py
+++ b/tests/test_multimedia_image_api.py
@@ -12,14 +12,15 @@
 from io import BytesIO
 
 import pytest
+from PIL import Image
 
+from flask_iiif.api import MultimediaImage
 from flask_iiif.utils import create_gif_from_frames
 
 from .helpers import IIIFTestCase
 
 
 class TestMultimediaAPI(IIIFTestCase):
-
     """Multimedia Image API test case."""
 
     @pytest.mark.parametrize("width, height",
@@ -32,8 +33,7 @@ class TestMultimediaAPI(IIIFTestCase):
     def setUp(self, width=1280, height=1024):
         """Run before the test."""
         # Create an image in memory
-        from PIL import Image
-        from flask_iiif.api import MultimediaImage
+
         tmp_file = BytesIO()
         # create a new image
         image = Image.new("RGBA", (width, height), (255, 0, 0, 0))


### PR DESCRIPTION
* fixes for best fit case (f.e. dimensions !400,200) -
  changed variable in the formula

* expected behaviour for best fit case changed
  - now it resizes the image and keeps the ratio of
  an image and fills the background to requested size
  with black pixels - this helps to keep responsive
  images in the UI

* adds the function to fill the pixels with
  black background if the best fit is smaller
  than requested thumbnail box size - preserves
  the thumbnail ratio

* add the function to fill the background with
  black pixels for GIF if the best fit is
  smaller than requested window size

* provides testing cases for portrait, landscape
  and fixed best fit case

* related to requested fix: (closes #47).