### PR TITLE
fix for cache-control headers

### DIFF
--- a/flask_iiif/utils.py
+++ b/flask_iiif/utils.py
@@ -141,3 +141,14 @@ def fill_background(image, demand_width, demand_height):
         offset_y = max(1, int((demand_height - h) / 2))
     background.paste(image, (offset_x, offset_y))
     return background
+
+
+def should_cache(request_args):
+    """Check the request args for cache-control specifications.
+
+    :param request_args: flask request args
+    """
+    if "cache-control" in request_args \
+            and request_args['cache-control'] in ["no-cache", "no-store"]:
+        return False
+    return True


### PR DESCRIPTION
Added a check for cache control headers whereby the presence of a "no-cache" or "no-store" parameter results in the item not being cached.

(Closes #49)