### PR TITLE
docs: fix IIIF_FORMATS not showing in the docs

### DIFF
--- a/flask_iiif/config.py
+++ b/flask_iiif/config.py
@@ -32,7 +32,7 @@
 
     The supported image converters.
 
-.. py:data: IIIF_FORMATS
+.. py:data:: IIIF_FORMATS
 
     The supported image formats with their MIME type.
 


### PR DESCRIPTION
IIIF_FORMATS were not present in readthedocs.