### PR TITLE
redis_cache: adding key_prefix set from config with default value 'iiif'

### DIFF
--- a/flask_iiif/cache/redis.py
+++ b/flask_iiif/cache/redis.py
@@ -25,7 +25,11 @@ class ImageRedisCache(ImageCache):
         """Initialize the cache."""
         super(ImageRedisCache, self).__init__()
         redis_url = current_app.config['IIIF_CACHE_REDIS_URL']
-        self.cache = RedisCache(host=StrictRedis.from_url(redis_url))
+        prefix = current_app.config.get('IIIF_CACHE_REDIS_PREFIX', 'iiif')
+        self.cache = RedisCache(
+            host=StrictRedis.from_url(redis_url),
+            key_prefix=prefix
+        )
 
     def get(self, key):
         """Return the key value.

--- a/flask_iiif/config.py
+++ b/flask_iiif/config.py
@@ -15,6 +15,10 @@
 
     .. seealso:: :py:class:`~flask_iiif.cache.cache.ImageCache`
 
+.. py:data:: IIIF_CACHE_REDIS_PREFIX
+
+    Sets prefix for redis keys, default: `iiif`
+
 .. py:data:: IIIF_CACHE_TIME
 
     How much time the image would be cached.


### PR DESCRIPTION
closes #55 