### PR TITLE
Specfixes

### DIFF
--- a/flask_iiif/api.py
+++ b/flask_iiif/api.py
@@ -407,14 +407,20 @@ class MultimediaImage(MultimediaObject):
             converted to `RGB` mode.
 
         """
-        image_format = self.sanitize_format_name(requested_format)
+        pil_map = current_app.config['IIIF_FORMATS_PIL_MAP']
+        pil_keys = pil_map.keys()
         format_keys = current_app.config['IIIF_FORMATS'].keys()
 
-        if image_format not in format_keys:
+        if (
+            requested_format not in format_keys or
+            requested_format not in pil_keys
+        ):
             raise MultimediaImageFormatError(
-                ("{0} does not supported, please select on of the valid"
+                ("{0} is not supported, please select one of the valid"
                  " formats: {1}").format(requested_format, format_keys)
             )
+        else:
+            image_format = pil_map[requested_format]
 
         # If the the `requested_format` is pdf or jpeg force mode to RGB
         if image_format in ("pdf", "jpeg"):
@@ -431,11 +437,6 @@ class MultimediaImage(MultimediaObject):
     def percent_to_number(number):
         """Calculate the percentage."""
         return float(number) / 100.0
-
-    @staticmethod
-    def sanitize_format_name(value):
-        """Lowercase formats and make sure that jpg is written as jpeg."""
-        return value.lower().replace("jpg", "jpeg")
 
 
 class IIIFImageAPIWrapper(MultimediaImage):

--- a/flask_iiif/api.py
+++ b/flask_iiif/api.py
@@ -23,7 +23,7 @@ from .errors import IIIFValidatorError, MultimediaImageCropError, \
     MultimediaImageFormatError, MultimediaImageNotFound, \
     MultimediaImageQualityError, MultimediaImageResizeError, \
     MultimediaImageRotateError
-from .utils import fill_background, resize_gif, resize_with_background_gif
+from .utils import resize_gif
 
 
 class MultimediaObject(object):
@@ -131,7 +131,7 @@ class MultimediaImage(MultimediaObject):
 
         """
         real_width, real_height = self.image.size
-        fits, point_x, point_y = True, 0, 0
+        point_x, point_y = 0, 0
         if resample is None:
             if isinstance(current_app.config['IIIF_RESIZE_RESAMPLE'],
                           string_types):
@@ -171,9 +171,6 @@ class MultimediaImage(MultimediaObject):
             # calculate the dimensions
             width = max(1, int(real_width * ratio))
             height = max(1, int(real_height * ratio))
-            # check if it's not too small for the requested window
-            if not (width == point_x and height == point_y):
-                fits = False
 
         # Check if it is `w,`
         elif dimensions.endswith(','):
@@ -202,18 +199,9 @@ class MultimediaImage(MultimediaObject):
 
         arguments = dict(size=(width, height), resample=resample)
         if self.image.format == 'GIF':
-            if not fits:
-                self.image = resize_with_background_gif(
-                    self.image, demand_w=point_x, demand_h=point_y,
-                    **arguments)
-            else:
-                self.image = resize_gif(self.image, **arguments)
+            self.image = resize_gif(self.image, **arguments)
         else:
-            if fits:
-                self.image = self.image.resize(**arguments)
-            else:
-                self.image = fill_background(self.image.resize(**arguments),
-                                             point_x, point_y)
+            self.image = self.image.resize(**arguments)
 
     def crop(self, coordinates):
         """Crop the image.

--- a/flask_iiif/config.py
+++ b/flask_iiif/config.py
@@ -86,11 +86,24 @@ IIIF_CONVERTERS = '', 'L', 'L', '1', '', ''
 # Supported multimedia image API formats
 IIIF_FORMATS = {
     'gif': 'image/gif',
+    'jp2': 'image/jp2',
     'jpeg': 'image/jpeg',
     'jpg': 'image/jpeg',
     'pdf': 'application/pdf',
     'png': 'image/png',
     'tif': 'image/tiff',
+    'tiff': 'image/tiff'
+}
+
+IIIF_FORMATS_PIL_MAP = {
+    'gif': 'gif',
+    'jp2': 'jpeg2000',
+    'jpeg': 'jpeg',
+    'jpg': 'jpeg',
+    'pdf': 'pdf',
+    'png': 'png',
+    'tif': 'tiff',
+    'tiff': 'tiff'
 }
 
 # Regular expressions to validate each parameter
@@ -115,7 +128,7 @@ IIIF_VALIDATIONS = {
         },
         "image_format": {
             "ignore": "",
-            "validate": "(jpg|png|gif|jp2|jpeg|pdf|tif)"
+            "validate": "(gif|jp2|jpe?g|pdf|png|tiff?)"
         }
     },
     "v2": {
@@ -138,7 +151,7 @@ IIIF_VALIDATIONS = {
         },
         "image_format": {
             "ignore": "",
-            "validate": "(jpg|png|gif|jp2|jpeg|pdf|tif)"
+            "validate": "(gif|jp2|jpe?g|pdf|png|tiff?)"
         }
     }
 }

--- a/flask_iiif/config.py
+++ b/flask_iiif/config.py
@@ -78,10 +78,10 @@ IIIF_CACHE_REDIS_URL = 'redis://localhost:6379/0'
 
 # Supported qualities
 IIIF_QUALITIES = (
-    'default', 'grey', 'bitonal', 'color', 'native'
+    'default', 'gray', 'grey', 'bitonal', 'color', 'native'
 )
 # Suported coverters
-IIIF_CONVERTERS = '', 'L', '1', '', ''
+IIIF_CONVERTERS = '', 'L', 'L', '1', '', ''
 
 # Supported multimedia image API formats
 IIIF_FORMATS = {
@@ -111,7 +111,7 @@ IIIF_VALIDATIONS = {
         },
         "quality": {
             "ignore": "default",
-            "validate": "(native|color|grey|bitonal)"
+            "validate": "(native|color|gr[ae]y|bitonal)"
         },
         "image_format": {
             "ignore": "",
@@ -134,7 +134,7 @@ IIIF_VALIDATIONS = {
         },
         "quality": {
             "ignore": "default",
-            "validate": "(default|color|grey|bitonal)"
+            "validate": "(default|color|gr[ae]y|bitonal)"
         },
         "image_format": {
             "ignore": "",
@@ -146,14 +146,14 @@ IIIF_VALIDATIONS = {
 # Qualities per image mode
 IIIF_MODE = {
     '1': ['default', 'bitonal'],
-    'L': ['default', 'gray', 'bitonal'],
-    'P': ['default', 'gray', 'bitonal'],
-    'RGB': ['default', 'color', 'gray', 'bitonal'],
-    'RGBA': ['default', 'color', 'gray', 'bitonal'],
-    'CMYK': ['default', 'color', 'gray', 'bitonal'],
-    'YCbCr': ['default', 'color', 'gray', 'bitonal'],
-    'I': ['default', 'color', 'gray', 'bitonal'],
-    'F': ['default', 'color', 'gray', 'bitonal']
+    'L': ['default', 'gray', 'grey', 'bitonal'],
+    'P': ['default', 'gray', 'grey', 'bitonal'],
+    'RGB': ['default', 'color', 'gray', 'grey', 'bitonal'],
+    'RGBA': ['default', 'color', 'gray', 'grey', 'bitonal'],
+    'CMYK': ['default', 'color', 'gray', 'grey', 'bitonal'],
+    'YCbCr': ['default', 'color', 'gray', 'grey', 'bitonal'],
+    'I': ['default', 'color', 'gray', 'grey', 'bitonal'],
+    'F': ['default', 'color', 'gray', 'grey', 'bitonal']
 }
 
 # API Info

--- a/flask_iiif/restful.py
+++ b/flask_iiif/restful.py
@@ -22,7 +22,6 @@ from werkzeug.utils import secure_filename
 
 from .api import IIIFImageAPIWrapper
 from .decorators import api_decorator, error_handler
-from .errors import MultimediaImageNotFound
 from .signals import iiif_after_info_request, iiif_after_process_request, \
     iiif_before_info_request, iiif_before_process_request
 from .utils import datetime_to_float, should_cache
@@ -76,10 +75,7 @@ class IIIFImageInfo(Resource):
             width, height = map(int, cached.split(','))
         else:
             data = current_iiif.uuid_to_image_opener(uuid)
-            try:
-                image = IIIFImageAPIWrapper.open_image(data)
-            except:
-                raise(MultimediaImageNotFound)
+            image = IIIFImageAPIWrapper.open_image(data)
             width, height = image.size()
             if should_cache(request.args):
                 cache_handler.set(key, "{0},{1}".format(width, height))
@@ -165,10 +161,8 @@ class IIIFImageAPI(Resource):
         # Otherwise create the image
         else:
             data = current_iiif.uuid_to_image_opener(uuid)
-            try:
-                image = IIIFImageAPIWrapper.open_image(data)
-            except:
-                raise(MultimediaImageNotFound)
+            image = IIIFImageAPIWrapper.open_image(data)
+
             image.apply_api(
                 version=version,
                 region=region,

--- a/flask_iiif/restful.py
+++ b/flask_iiif/restful.py
@@ -79,7 +79,7 @@ class IIIFImageInfo(Resource):
             try:
                 image = IIIFImageAPIWrapper.open_image(data)
             except:
-                raise(MultimediaImageNotFound)
+                raise MultimediaImageNotFound()
             width, height = image.size()
             if should_cache(request.args):
                 cache_handler.set(key, "{0},{1}".format(width, height))
@@ -168,7 +168,7 @@ class IIIFImageAPI(Resource):
             try:
                 image = IIIFImageAPIWrapper.open_image(data)
             except:
-                raise(MultimediaImageNotFound)
+                raise MultimediaImageNotFound()
             image.apply_api(
                 version=version,
                 region=region,

--- a/flask_iiif/restful.py
+++ b/flask_iiif/restful.py
@@ -79,7 +79,7 @@ class IIIFImageInfo(Resource):
             try:
                 image = IIIFImageAPIWrapper.open_image(data)
             except:
-                raise MultimediaImageNotFound()
+                raise(MultimediaImageNotFound)
             width, height = image.size()
             if should_cache(request.args):
                 cache_handler.set(key, "{0},{1}".format(width, height))
@@ -168,7 +168,7 @@ class IIIFImageAPI(Resource):
             try:
                 image = IIIFImageAPIWrapper.open_image(data)
             except:
-                raise MultimediaImageNotFound()
+                raise(MultimediaImageNotFound)
             image.apply_api(
                 version=version,
                 region=region,

--- a/flask_iiif/restful.py
+++ b/flask_iiif/restful.py
@@ -99,7 +99,10 @@ class IIIFImageInfo(Resource):
         # Trigger event after proccess the api request
         iiif_after_info_request.send(self, **data)
 
-        return jsonify(data)
+        resp = jsonify(data)
+        if 'application/ld+json' in request.headers.get('Accept', ''):
+            resp.mimetype = 'application/ld+json'
+        return resp
 
 
 class IIIFImageAPI(Resource):

--- a/flask_iiif/restful.py
+++ b/flask_iiif/restful.py
@@ -22,6 +22,7 @@ from werkzeug.utils import secure_filename
 
 from .api import IIIFImageAPIWrapper
 from .decorators import api_decorator, error_handler
+from .errors import MultimediaImageNotFound
 from .signals import iiif_after_info_request, iiif_after_process_request, \
     iiif_before_info_request, iiif_before_process_request
 from .utils import datetime_to_float, should_cache
@@ -75,7 +76,10 @@ class IIIFImageInfo(Resource):
             width, height = map(int, cached.split(','))
         else:
             data = current_iiif.uuid_to_image_opener(uuid)
-            image = IIIFImageAPIWrapper.open_image(data)
+            try:
+                image = IIIFImageAPIWrapper.open_image(data)
+            except:
+                raise(MultimediaImageNotFound)
             width, height = image.size()
             if should_cache(request.args):
                 cache_handler.set(key, "{0},{1}".format(width, height))
@@ -158,8 +162,10 @@ class IIIFImageAPI(Resource):
         # Otherwise create the image
         else:
             data = current_iiif.uuid_to_image_opener(uuid)
-            image = IIIFImageAPIWrapper.open_image(data)
-
+            try:
+                image = IIIFImageAPIWrapper.open_image(data)
+            except:
+                raise(MultimediaImageNotFound)
             image.apply_api(
                 version=version,
                 region=region,

--- a/flask_iiif/utils.py
+++ b/flask_iiif/utils.py
@@ -107,44 +107,6 @@ def resize_gif(image, size, resample):
                                   for frame in ImageSequence.Iterator(image)])
 
 
-def resize_with_background_gif(image, size, resample, demand_w=0, demand_h=0):
-    """Resize a GIF image and fills the missing pixels with black background.
-
-    :param image: the original GIF image
-    :param size: the dimensions to resize to
-    :param resample: the method of resampling
-    :param demand_w: demanded height for thumbnail
-    :param demand_h: demanded width for thumbnail
-    :returns: resized GIF image
-    :rtype: PIL.Image
-    """
-    return create_gif_from_frames([fill_background(
-        frame.resize(size, resample=resample), demand_w, demand_h)
-        for frame in ImageSequence.Iterator(image)])
-
-
-def fill_background(image, demand_width, demand_height):
-    """Fill the background with black (in case of image too small).
-
-    :param image: image which does not fit into the window
-    :param demand_width: demanded thumbnail window width
-    :param demand_height: demanded window height
-    :returns: image of requested size, filled with black background
-    :rtype: PIL.Image
-    """
-    background = Image.new('RGB', (demand_width, demand_height))
-    offset_x, offset_y = 0, 0
-    w, h = image.size
-    if w < demand_width:
-        # set the image in the middle of x axis
-        offset_x = max(1, int((demand_width - w) / 2))
-    if h < demand_height:
-        # set the image in the middle of y axis
-        offset_y = max(1, int((demand_height - h) / 2))
-    background.paste(image, (offset_x, offset_y))
-    return background
-
-
 def should_cache(request_args):
     """Check the request args for cache-control specifications.
 

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ tests_require = [
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
     'pytest>=2.6.1',
+    'Werkzeug>=0.15,<1.0.0'
 ]
 
 install_requires = [

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ tests_require = [
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
     'pytest>=2.6.1',
-    'Werkzeug>=0.15,<1.0.0'
+    'Werkzeug>=0.15'
 ]
 
 install_requires = [

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ install_requires = [
     'Flask-RESTful>=0.2.12',
     'blinker>=1.4',
     'six>=1.7.2',
-    'pillow>=3.4',
+    'pillow>=4.0',
 ]
 
 extra_require = {

--- a/tests/test_multimedia_image_api.py
+++ b/tests/test_multimedia_image_api.py
@@ -100,7 +100,7 @@ class TestMultimediaAPI(IIIFTestCase):
         self.image_gif.resize('!400,220')
         self.assertEqual(self.image_gif.image.is_animated, True)
         self.assertEqual(self.image_gif.image.n_frames, 5)
-        self.assertEqual(str(self.image_gif.size()), str((400, 220)))
+        self.assertEqual(str(self.image_gif.size()), str((232, 220)))
 
     def test_image_resize(self):
         """Test image resize function."""
@@ -126,7 +126,7 @@ class TestMultimediaAPI(IIIFTestCase):
 
         # Resize.image_resize to !100,100
         self.image_resize.resize('!100,100')
-        self.assertEqual(str(self.image_resize.size()), str((100, 100)))
+        self.assertEqual(str(self.image_resize.size()), str((100, 94)))
 
     def test_errors(self):
         """Test errors."""

--- a/tests/test_multimedia_image_api.py
+++ b/tests/test_multimedia_image_api.py
@@ -209,7 +209,7 @@ class TestMultimediaAPI(IIIFTestCase):
         self.assertEqual(str(self.image_rotate.size()), str((1024, 1280)))
 
         self.image_rotate.rotate(120)
-        self.assertEqual(str(self.image_rotate.size()), str((1024, 1280)))
+        self.assertEqual(str(self.image_rotate.size()), str((1622, 1528)))
 
     def test_image_mode(self):
         """Test image mode."""


### PR DESCRIPTION
Fixes a number of deviations from the IIIF spec and a couple of bugs. 

This now passes all tests for level 2 compliance (and some optional ones) by the IIIF Image API validator service.

There are some possibly breaking changes where non-compliant behaviour is expected by consumers of the existing API implementation - 

* !w,h regions are no longer padded to the specified w,h - the returned image will be no larger than w,h and maintain the aspect of the selected region.
* rotations are applied clockwise
* mirroring is applied before rotation
* rotations will be put into an expanded canvas when needed

closes #75 
closes #74 
closes #72
closes #47 