### PR TITLE
restful: close image after usage to avoid leaking memory

### DIFF
--- a/flask_iiif/api.py
+++ b/flask_iiif/api.py
@@ -581,3 +581,7 @@ class IIIFImageAPIWrapper(MultimediaImage):
         except (AttributeError, IOError):
             raise MultimediaImageNotFound("The requested image cannot be opened")
         return cls(image)
+
+    def close_image(self):
+        """Close an image file descriptor."""
+        self.image.close()

--- a/flask_iiif/restful.py
+++ b/flask_iiif/restful.py
@@ -76,6 +76,7 @@ class IIIFImageInfo(Resource):
             data = current_iiif.uuid_to_image_opener(uuid)
             image = IIIFImageAPIWrapper.open_image(data)
             width, height = image.size()
+            image.close_image()
             if should_cache(request.args):
                 try:
                     current_iiif.cache.set(key, "{0},{1}".format(width, height))
@@ -174,7 +175,7 @@ class IIIFImageAPI(Resource):
 
             # prepare image to be serve
             to_serve = image.serve(image_format=image_format)
-            # to_serve = image.serve(image_format=image_format)
+            image.close_image()
             if should_cache(request.args):
                 try:
                     current_iiif.cache.set(key, to_serve.getvalue())


### PR DESCRIPTION
closes https://github.com/inveniosoftware/flask-iiif/issues/85

Did not test a full stack integration (i.e. newly deployed instance). However, there are unit tests for the sections of the code that are touched, which fail if the image is closed before usage.