### PR TITLE
GIF: Remove gif_resize handler

### DIFF
--- a/flask_iiif/api.py
+++ b/flask_iiif/api.py
@@ -29,7 +29,6 @@ from .errors import (
     MultimediaImageResizeError,
     MultimediaImageRotateError,
 )
-from .utils import resize_gif
 
 
 class MultimediaObject(object):
@@ -207,10 +206,7 @@ class MultimediaImage(MultimediaObject):
             )
 
         arguments = dict(size=(width, height), resample=resample)
-        if self.image.format == "GIF":
-            self.image = resize_gif(self.image, **arguments)
-        else:
-            self.image = self.image.resize(**arguments)
+        self.image = self.image.resize(**arguments)
 
     def crop(self, coordinates):
         """Crop the image.

--- a/flask_iiif/utils.py
+++ b/flask_iiif/utils.py
@@ -64,52 +64,6 @@ def iiif_image_url(**kwargs):
         )
 
 
-def create_gif_from_frames(frames, duration=500, loop=0):
-    """Create a GIF image.
-
-    :param frames: the sequence of frames that resulting GIF should contain
-    :param duration: the duration of each frame (in milliseconds)
-    :param loop: the number of iterations of the frames (0 for infinity)
-    :returns: GIF image
-    :rtype: PIL.Image
-
-    .. note:: Uses ``tempfile``, as PIL allows GIF creation only on ``save``.
-    """
-    # Save GIF to temporary file
-    tmp = tempfile.mkdtemp(dir=current_app.config["IIIF_GIF_TEMP_FOLDER_PATH"])
-    tmp_file = join(tmp, "temp.gif")
-
-    head, tail = frames[0], frames[1:]
-    head.save(
-        tmp_file, "GIF", save_all=True, append_images=tail, duration=duration, loop=loop
-    )
-
-    gif_image = Image.open(tmp_file)
-    assert gif_image.is_animated
-
-    # Cleanup temporary file
-    shutil.rmtree(tmp)
-
-    return gif_image
-
-
-def resize_gif(image, size, resample):
-    """Resize a GIF image.
-
-    :param image: the original GIF image
-    :param size: the dimensions to resize to
-    :param resample: the method of resampling
-    :returns: resized GIF image
-    :rtype: PIL.Image
-    """
-    return create_gif_from_frames(
-        [
-            frame.resize(size, resample=resample)
-            for frame in ImageSequence.Iterator(image)
-        ]
-    )
-
-
 def should_cache(request_args):
     """Check the request args for cache-control specifications.
 

--- a/tests/test_multimedia_image_api.py
+++ b/tests/test_multimedia_image_api.py
@@ -16,7 +16,6 @@ import pytest
 from PIL import Image
 
 from flask_iiif.api import MultimediaImage
-from flask_iiif.utils import create_gif_from_frames
 
 from .helpers import IIIFTestCase
 
@@ -36,17 +35,8 @@ class TestMultimediaAPI(IIIFTestCase):
         # create a new image
         image = Image.new("RGBA", (width, height), (255, 0, 0, 0))
         image.save(tmp_file, "png")
-
-        # create a new gif image
-        self.image_gif = MultimediaImage(
-            create_gif_from_frames(
-                [
-                    Image.new("RGB", (width, height), color)
-                    for color in ["blue", "yellow", "red", "black", "white"]
-                ]
-            )
-        )
         self.width, self.height = width, height
+
         # Initialize it for our object and create and instance for
         # each test
         tmp_file.seek(0)
@@ -83,25 +73,6 @@ class TestMultimediaAPI(IIIFTestCase):
         image.save(tmp_file, "tiff")
         tmp_file.seek(0)
         self.image_tiff = MultimediaImage.from_string(tmp_file)
-
-    def test_gif_resize(self):
-        """Test image resize function on GIF images."""
-        # Check original size and GIF properties
-        self.assertEqual(self.image_gif.image.is_animated, True)
-        self.assertEqual(self.image_gif.image.n_frames, 5)
-        self.assertEqual(str(self.image_gif.size()), str((self.width, self.height)))
-
-        # Assert proper resize and preservation of GIF properties
-        self.image_gif.resize("720,680")
-        self.assertEqual(self.image_gif.image.is_animated, True)
-        self.assertEqual(self.image_gif.image.n_frames, 5)
-        self.assertEqual(str(self.image_gif.size()), str((720, 680)))
-
-        # test gif resize best fit
-        self.image_gif.resize("!400,220")
-        self.assertEqual(self.image_gif.image.is_animated, True)
-        self.assertEqual(self.image_gif.image.n_frames, 5)
-        self.assertEqual(str(self.image_gif.size()), str((232, 220)))
 
     def test_image_resize(self):
         """Test image resize function."""


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

create_gif_from_frames / resize_gif were throwing errors with current versions of Pillow. On closer investigation, these had no effect even when working there's so I've removed them.

The functions:

* Treated alll GIFs as a sequence.
* Only gave resize special treatment - all other IIIF operations reduce the GIF to its opening frame (- which in most cases is preferable, since -)
* IIIF doesn't play well with animated GIFs - a primary use case is tiling large images and the tiles are not synronizable.

(The original animated GIF is still downloadable, unmodified by the IIIF API as  with other files)

Closes #91 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [X] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [X] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [X] I've added relevant test cases.
- [X] I've added relevant documentation.
- [X] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [X] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [X] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [X] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [X] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [X] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
