### PR TITLE
API/resize: fix failure on greyscale images

### DIFF
--- a/flask_iiif/api.py
+++ b/flask_iiif/api.py
@@ -122,7 +122,7 @@ class MultimediaImage(MultimediaObject):
         """Resize the image.
 
         :param str dimensions: The dimensions to resize the image
-        :param resample: The algorithm to be used
+        :param resample: The algorithm to be used. Use Pillow default if not supplied.
         :type resample: :py:mod:`PIL.Image` algorithm
 
         .. note::
@@ -200,7 +200,7 @@ class MultimediaImage(MultimediaObject):
                 ).format(width, height)
             )
 
-        arguments = dict(size=(width, height), resample=resample)
+        arguments = dict(size=(width, height))
         if resample:
             arguments["resample"] = resample
         self.image = self.image.resize(**arguments)

--- a/flask_iiif/api.py
+++ b/flask_iiif/api.py
@@ -138,11 +138,6 @@ class MultimediaImage(MultimediaObject):
         """
         real_width, real_height = self.image.size
         point_x, point_y = 0, 0
-        if resample is None:
-            if isinstance(current_app.config["IIIF_RESIZE_RESAMPLE"], string_types):
-                resample = import_string(current_app.config["IIIF_RESIZE_RESAMPLE"])
-            else:
-                resample = current_app.config["IIIF_RESIZE_RESAMPLE"]
 
         # Check if it is `pct:`
         if dimensions.startswith("pct:"):
@@ -206,6 +201,8 @@ class MultimediaImage(MultimediaObject):
             )
 
         arguments = dict(size=(width, height), resample=resample)
+        if resample:
+            arguments["resample"] = resample
         self.image = self.image.resize(**arguments)
 
     def crop(self, coordinates):

--- a/flask_iiif/config.py
+++ b/flask_iiif/config.py
@@ -63,9 +63,6 @@
         <http://iiif.io/api/image/2.0/#information-request>`_
 
 """
-# Resampling method
-IIIF_RESIZE_RESAMPLE = "PIL.Image:BICUBIC"
-
 # Cache handler
 IIIF_CACHE_HANDLER = "flask_iiif.cache.simple:ImageSimpleCache"
 

--- a/flask_iiif/restful.py
+++ b/flask_iiif/restful.py
@@ -214,7 +214,7 @@ class IIIFImageAPI(Resource):
                 )
             send_file_kwargs.update(
                 as_attachment=True,
-                attachment_filename=secure_filename(filename),
+                download_name=secure_filename(filename),
             )
         if_modified_since_raw = request.headers.get("If-Modified-Since")
         if if_modified_since_raw:

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ zip_safe = False
 install_requires =
     blinker>=1.4
     cachelib>=0.1
-    Flask>=1.0.4
+    Flask>=2.0
     Flask-RESTful>=0.3.7
     pillow>=7.0
     six>=1.7.2
@@ -39,7 +39,7 @@ tests =
     pytest-black>=0.3.0,<0.3.10
     flask-testing>=0.6.0
     pytest-invenio>=1.4.0
-    werkzeug>=0.15.3
+    werkzeug<3.0
     sphinx>=4.5
     redis>=3.5
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     cachelib>=0.1
     Flask>=1.0.4
     Flask-RESTful>=0.3.7
-    pillow>=4.0
+    pillow>=7.0
     six>=1.7.2
 
 [options.extras_require]

--- a/tests/test_restful_api.py
+++ b/tests/test_restful_api.py
@@ -308,7 +308,6 @@ class TestRestAPI(IIIFTestCase):
         cache.clear()
 
         for cache_control, name in (("no-cache", "foo.pdf"), ("no-store", "foo.pdf")):
-
             urlargs["cache-control"] = cache_control
 
             get_the_response = self.get(
@@ -323,7 +322,6 @@ class TestRestAPI(IIIFTestCase):
             cache.clear()
 
         for cache_control, name in (("public", "foo.pdf"), ("no-transform", "foo.pdf")):
-
             urlargs["cache-control"] = cache_control
 
             get_the_response = self.get(

--- a/tests/test_restful_api_with_redis.py
+++ b/tests/test_restful_api_with_redis.py
@@ -308,7 +308,6 @@ class TestRestAPI(IIIFTestCaseWithRedis):
         cache.clear()
 
         for cache_control, name in (("no-cache", "foo.pdf"), ("no-store", "foo.pdf")):
-
             urlargs["cache-control"] = cache_control
 
             get_the_response = self.get(
@@ -323,7 +322,6 @@ class TestRestAPI(IIIFTestCaseWithRedis):
             cache.clear()
 
         for cache_control, name in (("public", "foo.pdf"), ("no-transform", "foo.pdf")):
-
             urlargs["cache-control"] = cache_control
 
             get_the_response = self.get(


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

As reported by @fenekku - resize operations were failing on greyscale images. This was caused by the method specified in IIIIF_RESIZE_RESAMPLE being applied to all image regardles of mode.

This setting appears to have been added to force Pillow to perform (higher quality) bicubic resampling on colour images. 
Since Pillow 7.0, bicubic is used by default on colour images - thus we can simply bump the Pillow version requirement and remove the override / allow Pillow to select the most appropriate method. 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
