### PR TITLE
config: use raw strings for regular expressions

### DIFF
--- a/flask_iiif/config.py
+++ b/flask_iiif/config.py
@@ -107,32 +107,35 @@ IIIF_VALIDATIONS = {
     "v1": {
         "region": {
             "ignore": "full",
-            "validate": "(^full|(pct:)?([\d.]+,){3}([\d.]+))",
+            "validate": r"(^full|(pct:)?([\d.]+,){3}([\d.]+))",
         },
         "size": {
             "ignore": "full",
             "validate": (
-                "(^full|[\d.]+,|,[\d.]+|pct:[\d.]+|[\d.]+," "[\d.]+|![\d.]+,[\d.]+)"
+                r"(^full|[\d.]+,|,[\d.]+|pct:[\d.]+|[\d.]+,[\d.]+|![\d.]+,[\d.]+)"
             ),
         },
-        "rotation": {"ignore": "0", "validate": "^[\d.]+$"},
-        "quality": {"ignore": "default", "validate": "(native|color|gr[ae]y|bitonal)"},
-        "image_format": {"ignore": "", "validate": "(gif|jp2|jpe?g|pdf|png|tiff?)"},
+        "rotation": {"ignore": "0", "validate": r"^[\d.]+$"},
+        "quality": {"ignore": "default", "validate": r"(native|color|gr[ae]y|bitonal)"},
+        "image_format": {"ignore": "", "validate": r"(gif|jp2|jpe?g|pdf|png|tiff?)"},
     },
     "v2": {
         "region": {
             "ignore": "full",
-            "validate": "(^full|(pct:)?([\d.]+,){3}([\d.]+))",
+            "validate": r"(^full|(pct:)?([\d.]+,){3}([\d.]+))",
         },
         "size": {
             "ignore": "full",
             "validate": (
-                "(^full|[\d.]+,|,[\d.]+|pct:[\d.]+|[\d.]+," "[\d.]+|![\d.]+,[\d.]+)"
+                r"(^full|[\d.]+,|,[\d.]+|pct:[\d.]+|[\d.]+,[\d.]+|![\d.]+,[\d.]+)"
             ),
         },
-        "rotation": {"ignore": "0", "validate": "^!?[\d.]+$"},
-        "quality": {"ignore": "default", "validate": "(default|color|gr[ae]y|bitonal)"},
-        "image_format": {"ignore": "", "validate": "(gif|jp2|jpe?g|pdf|png|tiff?)"},
+        "rotation": {"ignore": "0", "validate": r"^!?[\d.]+$"},
+        "quality": {
+            "ignore": "default",
+            "validate": r"(default|color|gr[ae]y|bitonal)",
+        },
+        "image_format": {"ignore": "", "validate": r"(gif|jp2|jpe?g|pdf|png|tiff?)"},
     },
 }
 


### PR DESCRIPTION
When installing some packages via `uv` and running scripts, sometimes warnings are printed about invalid escape sequences that point to the config in Flask-IIIF and Selenium (v3).
This PR replaces the normal strings with raw strings that do not interpret escape sequences (which is typically more convenient for regular expressions).