### PR TITLE
setup: remove werkzeug pin

### DIFF
--- a/flask_iiif/__init__.py
+++ b/flask_iiif/__init__.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Flask-IIIF
 # Copyright (C) 2014, 2015, 2016, 2017 CERN.
+# Copyright (C) 2024 Graz University of Technology.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -27,9 +28,10 @@ or alternatively using the factory pattern:
 
 from __future__ import absolute_import
 
+from urllib.parse import urljoin as url_join
+
 from flask import current_app
 from six import string_types
-from werkzeug.urls import url_join
 from werkzeug.utils import cached_property, import_string
 
 from . import config

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 #
 # This file is part of Flask-IIIF
 # Copyright (C) 2014 CERN.
-# Copyright (C) 2022 Graz University of Technology.
+# Copyright (C) 2022-2024 Graz University of Technology.
 #
 # Flask-IIIF is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
@@ -36,10 +36,9 @@ install_requires =
 
 [options.extras_require]
 tests =
-    pytest-black>=0.3.0,<0.3.10
+    pytest-black-ng>=0.4.0
     flask-testing>=0.6.0
     pytest-invenio>=1.4.0
-    werkzeug<3.0
     sphinx>=4.5
     redis>=3.5
 


### PR DESCRIPTION
* to be forward compatible with flask >= 3.0.0

* the url_join will be removed in werkzeug >= 3.0.0 and could be
  replaced by the urllib.parse.urljoin function

* the DeprecationWarning in werkzeug itself says to use
  urllib.parse.urljoin instead

* the upper pin is not more necessary with this change
